### PR TITLE
Search

### DIFF
--- a/bbqs_master/src/JBrowse/View/Dialog/Search.js
+++ b/bbqs_master/src/JBrowse/View/Dialog/Search.js
@@ -140,7 +140,7 @@ function (
                                         locstring: Util.assembleLocString(elt.multipleLocations[j]),
                                         location: elt.multipleLocations[j],
                                         label: elt.name,
-                                        description: track.key || track.label || defaultTrack.key || defaultTrack.label || 'Unknown track',
+                                        description: track.label || track.key || defaultTrack.label || defaultTrack.key || 'Unknown track',
                                         tracks: track
                                     });
                                 }
@@ -150,7 +150,7 @@ function (
                                     locstring: Util.assembleLocString(elt.location),
                                     location: elt.location,
                                     label: elt.location.objectName,
-                                    description: track.key || track.label || defaultTrack.key || defaultTrack.label || 'Unknown track',
+                                    description: track.label || track.key || defaultTrack.label || defaultTrack.key || 'Unknown track',
                                     tracks: track
                                 });
                             }


### PR DESCRIPTION
add empty list so that multiple locations don't fail on null track
make whatever track is the known gene track the default to return on search results
change naming of this track so it is label based and more descriptive

